### PR TITLE
feat(storybook): add WithTitle story to Callout

### DIFF
--- a/apps/storybook/src/callout.stories.tsx
+++ b/apps/storybook/src/callout.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from "@hugeicons/core-free-icons"
 import { HugeiconsIcon } from "@hugeicons/react"
 
-import { Callout, CalloutDescription, CalloutIcon } from "@conty/ui"
+import { Callout, CalloutDescription, CalloutIcon, CalloutTitle } from "@conty/ui"
 
 const meta = {
   title: "Components/Callout",
@@ -116,6 +116,24 @@ export const Destructive: Story = {
       </CalloutIcon>
       <CalloutDescription>
         We could not complete your request. Please check your data and try again.
+      </CalloutDescription>
+    </Callout>
+  )
+}
+
+export const WithTitle: Story = {
+  render: (args) => (
+    <Callout {...args} className="max-w-md">
+      <CalloutIcon>
+        <HugeiconsIcon icon={InformationCircleIcon} size={20} strokeWidth={1.8} />
+      </CalloutIcon>
+      <CalloutTitle>Update Available</CalloutTitle>
+      <CalloutDescription>
+        You will need to upgrade to the{" "}
+        <a href="#" onClick={(event) => event.preventDefault()}>
+          newest Frosted-UI
+        </a>{" "}
+        version now.
       </CalloutDescription>
     </Callout>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -7272,7 +7272,7 @@
     },
     "packages/tokens": {
       "name": "@conty/tokens",
-      "version": "0.0.1"
+      "version": "0.1.0"
     },
     "packages/typescript-config": {
       "name": "@conty/tsconfig",
@@ -7280,7 +7280,7 @@
     },
     "packages/ui": {
       "name": "@conty/ui",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "dependencies": {
         "@conty/tokens": "*",
         "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
Adiciona uma nova story demonstrando o uso de `CalloutTitle` em conjunto com `CalloutDescription`, cobrindo um caso de uso real que não estava documentado no Storybook.

<img width="1920" height="1080" alt="Captura de Tela 2026-03-13 às 22 19 21" src="https://github.com/user-attachments/assets/6f53796f-4235-4bc8-a2a7-7b75cc13a843" />

<img width="1920" height="1080" alt="Captura de Tela 2026-03-13 às 22 19 29" src="https://github.com/user-attachments/assets/61cee607-0759-4a22-998d-2b74958104da" />
